### PR TITLE
quicker setup for alt-tutorial with npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 git clone https://github.com/goatslacker/alt-tutorial.git
 cd alt-tutorial
 npm install
-npm run build
-open index.html
+npm start
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "reactify": "^0.17.1"
   },
   "scripts": {
-    "build": "browserify -t [reactify --es6] src/App.jsx > build/app.js"
+    "build": "browserify -t [reactify --es6] src/App.jsx > build/app.js",
+    "start": "npm run build && open 'index.html' "
   },
   "author": "Josh Perez <josh@goatslacker.com>",
   "license": "MIT"


### PR DESCRIPTION
Just wanted to make it easier for users to get up and running with this, with an `npm start` command. I would be keen to add this and make it consistent in the iso examples too if that's ok. Thanks
