### PR TITLE
Change to webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,16 +4,19 @@
   "description": "A simple flux tutorial built with alt and react",
   "main": "server.js",
   "dependencies": {
-    "alt": "^0.16.0",
-    "react": "^0.12.2"
+    "alt": "^0.16.5",
+    "react": "^0.13.3"
   },
   "devDependencies": {
-    "browserify": "^8.0.3",
-    "reactify": "^0.17.1"
+    "babel": "^5.4.5",
+    "babel-core": "^5.4.5",
+    "babel-loader": "^5.1.3",
+    "node-libs-browser": "^0.5.0",
+    "webpack": "^1.9.7"
   },
   "scripts": {
-    "build": "browserify -t [reactify --es6] src/App.jsx > build/app.js",
-    "start": "npm run build && open 'index.html' "
+    "build": "webpack",
+    "start": "npm run build && open 'index.html'"
   },
   "author": "Josh Perez <josh@goatslacker.com>",
   "license": "MIT"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,26 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  entry: [ './src/App.jsx' ],
+  output: {
+    path: path.join(__dirname, 'build'),
+    filename: 'app.js',
+    publicPath: '/build/'
+  },
+  plugins: [
+    new webpack.NoErrorsPlugin()
+  ],
+  resolve: {
+    extensions: ['', '.js','jsx']
+  },
+  module: {
+    loaders: [{
+      test: /\.jsx?$/,
+      include: [
+        path.join(__dirname, 'src')
+      ],
+      loaders: ['babel']
+    }]
+  }
+};


### PR DESCRIPTION
Feel free to make any improvements.

Note that this existing code will **not work** on Windows: `"start": "npm run build && open 'index.html'"`

The `open` command is not recognized on Windows shell.

I only kept it because this is how you had it on master before I create this branch. I believe it should be changed if you want Windows users to have a running app without problems.
