### PR TITLE
Returning false from local does not skip it in LocationSource

### DIFF
--- a/src/sources/LocationSource.js
+++ b/src/sources/LocationSource.js
@@ -38,7 +38,7 @@ var LocationSource = {
 
       local() {
         // Never check locally, always fetch remotely.
-        return false;
+        return null;
       },
 
       success: LocationActions.updateLocations,


### PR DESCRIPTION
I just cloned the repo to take a look and it wasn't working right out the door. The documentation [here](http://alt.js.org/docs/async/) states that:

> local(state: object, …args: any)
> 
> This function is called first. **If a value is returned then a change event will be emitted from the store.**

By returning false it was actually causing local to be called over remote:

> remote(state: object, …args: any)
> 
> This function is called whenever we need to fetch a value remotely. **remote is only called if local returns null or undefined as its value**, or if shouldFetch returns true.

This quick change gets the project working again.
